### PR TITLE
Stop using arrays in firebase

### DIFF
--- a/screens/Challenges/ToDoScreen.js
+++ b/screens/Challenges/ToDoScreen.js
@@ -44,31 +44,35 @@ export default function ToDoScreen() {
 
   useEffect(() => {
     const currentUser = getUserId();
-    getAllAssignedChallenges(currentUser).then(challenges => {
-      const openedChallenges = [];
-      const unopenedChallenges = [];
-      // Filter opened and unopened challenges
-      for (const challenge of challenges) {
-        let opened = false;
-        if (challenge.hasOwnProperty("opened")) {
-          const openedUserObjects = challenge.opened;
-          for (const openedUser of Object.keys(openedUserObjects)) {
-            if (openedUser === currentUser) {
-              opened = true;
-              break;
+    getAllAssignedChallenges(currentUser)
+      .then(challenges => {
+        const openedChallenges = [];
+        const unopenedChallenges = [];
+        // Filter opened and unopened challenges
+        for (const challenge of challenges) {
+          let opened = false;
+          if (challenge.hasOwnProperty("opened")) {
+            const openedUserObjects = challenge.opened;
+            for (const openedUser of Object.keys(openedUserObjects)) {
+              if (openedUser === currentUser) {
+                opened = true;
+                break;
+              }
             }
           }
+          if (opened) {
+            openedChallenges.push(challenge);
+          } else {
+            unopenedChallenges.push(challenge);
+          }
         }
-        if (opened) {
-          openedChallenges.push(challenge);
-        } else {
-          unopenedChallenges.push(challenge);
-        }
-      }
-      setOpenedChallenges(openedChallenges);
-      setUnopenedChallenges(unopenedChallenges);
-      setChallengeCards(unopenedChallenges);
-    });
+        setOpenedChallenges(openedChallenges);
+        setUnopenedChallenges(unopenedChallenges);
+        setChallengeCards(unopenedChallenges);
+      })
+      .catch(() => {
+        console.log("Error: cannot get challenges for user");
+      });
   }, []);
 
   const getTimeLeftInMilliseconds = assignedTime => {

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -33,17 +33,15 @@ export default function ProfileScreen() {
   const [imageUrl, setImageUrl] = useState(null);
   useEffect(() => {
     const currentUser = getUserId();
-    console.log("current", currentUser);
+    //console.log("current", currentUser);
     getUsername(currentUser).then(name => {
       setName(name);
     });
-  }, []);
 
-  useEffect(() => {
     Permissions.askAsync(Permissions.CAMERA_ROLL);
-    console.log("current", currentUser);
+    //console.log("current", currentUser);
     getPicture(currentUser).then(image => {
-      console.log("image", image);
+      //console.log("image", image);
       setImageUrl(image);
     });
   }, []);

--- a/utils/db/challenges.js
+++ b/utils/db/challenges.js
@@ -1,7 +1,6 @@
 import firebase from "../firebase/firebase";
 
 import { getCurrentValue } from "./helper";
-import { getTeam } from "./teams";
 
 export async function openChallenge(assignedChallengeId, userId) {
   const openTime = firebase.database.ServerValue.TIMESTAMP;
@@ -77,7 +76,7 @@ export async function getAllAssignedChallenges(userId) {
       teamIds.map(async teamId => {
         return {
           challengeId: await getCurrentChallengeId(teamId),
-          team: await getTeam(teamId)
+          team: await getCurrentValue(`/teams/${teamId}/`)
         };
       })
     );

--- a/utils/db/challenges.js
+++ b/utils/db/challenges.js
@@ -67,10 +67,12 @@ export async function setCurrentChallenge(teamId) {
 
 export async function getAllAssignedChallenges(userId) {
   try {
-    const teamIds = await getCurrentValue(`/users/${userId}/teams`);
-    if (!teamIds) {
+    const teamIdsObj = await getCurrentValue(`/users/${userId}/teams`);
+    if (!teamIdsObj) {
       return [];
     }
+    // Use Object.values since everything in firebase is stored as an object
+    const teamIds = Object.values(teamIdsObj);
     const data = await Promise.all(
       teamIds.map(async teamId => {
         return {


### PR DESCRIPTION
Stop using arrays in firebase for list of users on a team and list of teams on a users. Replaced arrays with objects created using push. Previously, arrays caused weird problems because firebase is unhappy. Also this would cause correctness problems if two people added themselves to a team at the same time. 

The challenge list still uses arrays since it's static so it doesn't matter.

I also added some try/catch's plus got rid of the require cycle so all the warnings would go away.

Resolves #67 